### PR TITLE
Supply an alternate default sort column

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,11 +30,22 @@ SomeModel.asc  # equivalent to SomeModel.order("created_at asc")
 SomeModel.desc # equivalent to SomeModel.order("created_at desc")
 ```
 
-You can change this per query, by passing an alternate column.
+You can change this per query by passing an alternate column.
 
 ```ruby
 SomeModel.asc(:updated_at)  # equivalent to SomeModel.order("updated_at asc")
 SomeModel.desc(:updated_at) # equivalent to SomeModel.order("updated_at desc")
+```
+
+To change the default sort column for your entire application, use `Assorted.options`.
+
+```ruby
+# config/intializers/assorted.rb, for example
+Assorted.options[:sorting_column] = :id
+
+# then, elsewhere in your app
+SomeModel.asc  # equivalent to SomeModel.order("id asc")
+SomeModel.desc # equivalent to SomeModel.order("id desc")
 ```
 
 To change the default sort column for a given class, specify with `set_sorting_column`.

--- a/lib/assorted.rb
+++ b/lib/assorted.rb
@@ -3,6 +3,14 @@ require "active_record"
 require "assorted/version"
 require "assorted/scopes"
 
+module Assorted
+  def self.options
+    @options ||= {
+      sorting_column: :created_at,
+    }
+  end
+end
+
 ActiveSupport.on_load(:active_record) do
   extend Assorted::Scopes
 end

--- a/lib/assorted/scopes.rb
+++ b/lib/assorted/scopes.rb
@@ -23,7 +23,7 @@ module Assorted
     end
 
     def sorting_column
-      @sorting_column ||= :created_at
+      @sorting_column || Assorted.options[:sorting_column]
     end
 
     def sorting_column=(column)

--- a/spec/lib/assorted/scopes_spec.rb
+++ b/spec/lib/assorted/scopes_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Assorted::Scopes do
   end
 
   it "prevents SQL injection attacks" do
-    record = ExampleRecord.create
+    ExampleRecord.create
     injection_attempt = "created_at desc; delete * from example_records;"
 
     expect { ExampleRecord.asc(injection_attempt) }.to raise_exception(ActiveRecord::StatementInvalid)

--- a/spec/lib/assorted_spec.rb
+++ b/spec/lib/assorted_spec.rb
@@ -4,4 +4,17 @@ RSpec.describe Assorted do
   it "includes itself in ActiveRecord::Base" do
     expect(ActiveRecord::Base.ancestors).to include(Assorted::Scopes)
   end
+
+  describe "#options" do
+    it "defaults to sort with created_at" do
+      expect(Assorted.options[:sorting_column]).to eq :created_at
+    end
+
+    it "remembers the new options given to it" do
+      Assorted.options[:foo] = :bar
+
+      expect(Assorted.options[:foo]).to eq(:bar)
+    end
+  end
+
 end

--- a/spec/support/active_record.rb
+++ b/spec/support/active_record.rb
@@ -13,11 +13,10 @@ RSpec.configure do |config|
         table.timestamps
       end
 
-      original_sorting_column = ExampleRecord.send(:sorting_column)
-
       example.run
 
-      ExampleRecord.send(:sorting_column=, original_sorting_column)
+      ExampleRecord.send(:sorting_column=, nil)
+      Assorted.instance_variable_set(:@options, nil)
 
       raise ActiveRecord::Rollback
     end


### PR DESCRIPTION
Closes https://github.com/dribbble/assorted/issues/5.

Still `:created_at` by default, but change with `Assorted.options[:sorting_column] = :whatever`. The specific name of that option might change depending on how https://github.com/dribbble/assorted/issues/4 works out.
